### PR TITLE
fix(pulse): update for placeos-pulse 0.13.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -151,11 +151,11 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 6.6.3
+    version: 6.6.4
 
   placeos-pulse:
     git: https://github.com/placeos/pulse.git
-    version: 0.12.0
+    version: 0.13.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/src/placeos-triggers.cr
+++ b/src/placeos-triggers.cr
@@ -23,24 +23,22 @@ module PlaceOS::Triggers
       return
     end
 
-    if Pulse.saas?
-      instance_api_key = begin
-        Model::ApiKey.saas_api_key(
-          instance_domain: domain,
-          instance_email: email,
-        )
-      rescue error : Model::Error::InvalidSaasKey
-        Log.error(exception: error) { "failed to fetch the saas key for the instance" }
-        raise error
-      end
-    else
-      instance_api_key = nil
-    end
+    instance_api_key = if Pulse.saas?
+                         begin
+                           Model::ApiKey.saas_api_key(
+                             instance_domain: domain,
+                             instance_email: email,
+                           )
+                         rescue error : Model::Error::InvalidSaasKey
+                           Log.error(exception: error) { "failed to fetch the saas key for the instance" }
+                           raise error
+                         end
+                       else
+                         nil
+                       end
 
     # Generate pulse client
-    Pulse.from_environment(
-      instance_api_key,
-    )
+    Pulse.from_environment(instance_api_key)
   end
 
   def self.start_pulse : Nil


### PR DESCRIPTION
**Description of the change**

Resolve breaking changes introduced in PlaceOS/pulse v0.13.0

**Benefits**

SaaS instances will not post a token if an ApiKey exists for the instance.

**Possible drawbacks**

If the initial post of the token to portal fails, the instance will be unregistered.
A solution to this would be checking if the instance has been registered with a token before posting it again.