### PR TITLE
feat: update pulse client

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -95,7 +95,7 @@ shards:
 
   hashcash:
     git: https://github.com/place-labs/hashcash.git
-    version: 1.0.1
+    version: 1.0.2
 
   hot_topic:
     git: https://github.com/jgaskins/hot_topic.git
@@ -195,7 +195,7 @@ shards:
 
   placeos-pulse:
     git: https://github.com/placeos/pulse.git
-    version: 0.14.0
+    version: 1.0.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.yml
+++ b/shard.yml
@@ -40,7 +40,7 @@ dependencies:
   # PlaceOS Telemetry
   placeos-pulse:
     github: placeos/pulse
-    version: "~> 0.13, >= 0.13.1"
+    version: "~> 1.0"
 
   # Abstraction over changes
   placeos-resource:

--- a/src/controllers/webhook.cr
+++ b/src/controllers/webhook.cr
@@ -47,7 +47,7 @@ module PlaceOS::Triggers::Api
     # Return 204 if the state isn't loaded, 202 on success
     @[AC::Route::POST("/:id", status: {
       String => HTTP::Status::ACCEPTED,
-      Nil => HTTP::Status::NO_CONTENT,
+      Nil    => HTTP::Status::NO_CONTENT,
     })]
     def create : String?
       trig = trigger


### PR DESCRIPTION
no longer prevents service from launch if pulse client fails when configured
